### PR TITLE
Introduce pre_sendTokenToServer hook compatible with OpenKore executables

### DIFF
--- a/OTP/Core.pm
+++ b/OTP/Core.pm
@@ -2,25 +2,28 @@ package OTP::Core;
 
 use strict;
 
-use MIME::Base32 qw(decode_base32);
-use Digest::SHA qw(hmac_sha1);
+use Plugins;
+use lib $Plugins::current_plugin_folder;
+use OTP::Utils;
 
 sub generate_otp {
-    my ($seed) = @_;
+    my ($base32_secret) = @_;
+    my $secret = OTP::Utils::base32_decode($base32_secret);
+    my $time_step = 30;
+    my $counter = int(time() / $time_step);
+    my $high = ($counter >> 32) & 0xFFFFFFFF;
+    my $low  = $counter & 0xFFFFFFFF;
+    my $msg = pack("NN", $high, $low);
+    my $hash = OTP::Utils::hmac_sha1($secret, $msg);
 
-    # contador big‑endian 64 bits
-    my $counter = pack("Q>", int(time / 30));
+    my $offset = ord(substr($hash, -1)) & 0x0f;
+    my $binary = ((ord(substr($hash, $offset, 1)) & 0x7f) << 24) |
+                 ((ord(substr($hash, $offset+1, 1)) & 0xff) << 16) |
+                 ((ord(substr($hash, $offset+2, 1)) & 0xff) << 8) |
+                 (ord(substr($hash, $offset+3, 1)) & 0xff);
 
-    # decodifica Base32 com o módulo oficial
-    my $key = decode_base32(uc $seed);
-
-    # HMAC‑SHA1 e truncação dinâmica
-    my $hmac = hmac_sha1($counter, $key);
-    my $off  = ord(substr($hmac, -1)) & 0x0F;
-    my $bin  = unpack("N", substr($hmac, $off, 4)) & 0x7FFFFFFF;
-    my $otp  = $bin % (10 ** 6);
-
-    return sprintf "%0*d", 6, $otp;
+    my $otp = $binary % 1_000_000;
+    return sprintf("%06d", $otp);
 }
 
 1;

--- a/OTP/Utils.pm
+++ b/OTP/Utils.pm
@@ -1,0 +1,96 @@
+package OTP::Utils;
+
+use strict;
+
+sub base32_decode {
+    my ($str) = @_;
+    $str =~ tr/A-Z2-7//cd;
+    my %map = map { substr("ABCDEFGHIJKLMNOPQRSTUVWXYZ234567", $_, 1) => $_ } 0..31;
+    my $bits = "";
+    foreach my $char (split //, uc($str)) {
+        my $val = $map{$char};
+        $bits .= sprintf("%05b", $val);
+    }
+    my $bytes = pack("B*", $bits);
+    return $bytes;
+}
+
+sub sha1 {
+    my $msg = shift;
+
+    my @h = (
+        0x67452301,
+        0xEFCDAB89,
+        0x98BADCFE,
+        0x10325476,
+        0xC3D2E1F0
+    );
+
+    my $ml = length($msg) * 8;
+    $msg .= chr(0x80);
+    $msg .= chr(0x00) while ((length($msg) % 64) != 56);
+    my $high = ($ml >> 32) & 0xFFFFFFFF;
+    my $low  = $ml & 0xFFFFFFFF;
+    $msg .= pack("NN", $high, $low);
+
+    foreach my $chunk (unpack("(a64)*", $msg)) {
+        my @w = unpack("N16", $chunk);
+        push @w, 0 for (16..79);
+        for my $i (16..79) {
+            $w[$i] = _rol($w[$i-3] ^ $w[$i-8] ^ $w[$i-14] ^ $w[$i-16], 1);
+        }
+
+        my ($a, $b, $c, $d, $e) = @h;
+
+        for my $i (0..79) {
+            my ($f, $k);
+            if ($i <= 19) {
+                $f = ($b & $c) | ((~$b) & $d);
+                $k = 0x5A827999;
+            } elsif ($i <= 39) {
+                $f = $b ^ $c ^ $d;
+                $k = 0x6ED9EBA1;
+            } elsif ($i <= 59) {
+                $f = ($b & $c) | ($b & $d) | ($c & $d);
+                $k = 0x8F1BBCDC;
+            } else {
+                $f = $b ^ $c ^ $d;
+                $k = 0xCA62C1D6;
+            }
+
+            my $temp = (_rol($a,5) + $f + $e + $k + $w[$i]) & 0xFFFFFFFF;
+            $e = $d;
+            $d = $c;
+            $c = _rol($b,30);
+            $b = $a;
+            $a = $temp;
+        }
+
+        $h[0] = ($h[0] + $a) & 0xFFFFFFFF;
+        $h[1] = ($h[1] + $b) & 0xFFFFFFFF;
+        $h[2] = ($h[2] + $c) & 0xFFFFFFFF;
+        $h[3] = ($h[3] + $d) & 0xFFFFFFFF;
+        $h[4] = ($h[4] + $e) & 0xFFFFFFFF;
+    }
+
+    return pack("N5", @h);
+}
+
+sub _rol {
+    my ($val, $bits) = @_;
+    return (($val << $bits) | ($val >> (32 - $bits))) & 0xFFFFFFFF;
+}
+
+sub hmac_sha1 {
+    my ($key, $data) = @_;
+    my $block_size = 64;
+    if (length($key) > $block_size) {
+        $key = sha1($key);
+    }
+    $key .= chr(0) x ($block_size - length($key));
+    my $o_key_pad = $key ^ (chr(0x5c) x $block_size);
+    my $i_key_pad = $key ^ (chr(0x36) x $block_size);
+    return sha1($o_key_pad . sha1($i_key_pad . $data));
+}
+
+1;

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ It listens for OTP requests and generates the correct TOTP code using the seed p
 * OpenKore (recent version with plugin system support)
 * A **Base32-encoded OTP seed** (provided by your game account)
 * Perl modules:
+  * `MIME::Base32`
   * `Digest::SHA`
 
 ---
@@ -29,11 +30,10 @@ Download `otp.pl` and put it in your OpenKore `plugins/` directory:
 /openkore/plugins/OTP/otp.pl
 ```
 
-Download `Core.pm` and `Utils.pm` and put it in your OpenKore `plugins/OTP` directory:
+Download `Core.pm` and put them in your OpenKore `plugins/OTP/` directory:
 
 ```
 /openkore/plugins/OTP/OTP/Core.pm
-/openkore/plugins/OTP/OTP/Utils.pm
 ```
 
 2️⃣ **Configure your OTP seed**
@@ -44,55 +44,12 @@ In your `config.txt` add your seed:
 otpSeed T0TPS33DROL4S3RV
 ```
 
-3️⃣ **Modify OpenKore source (important!)**
+3️⃣ **Ensure OpenKore core has the required hook**
 
-⚠ **OpenKore does not trigger a hook for OTP requests by default.**
-You must modify `src/Network/Receive.pm`:
+⚠ This plugin depends on OpenKore having the `pre_sendTokenToServer` hook implemented.
+➡ This is currently under review in the PR: [OpenKore PR #4036](https://github.com/OpenKore/openkore/pull/4036)
 
-Find the method:
-
-```perl
-sub received_login_token {
-```
-
-And replace this part:
-
-```perl
-sub received_login_token {
-	my ($self, $args) = @_;
-	# XKore mode 1 / 3.
-	return if ($self->{net}->version == 1);
-	my $master = $masterServers{$config{master}};
-
-	# rathena use 0064 not 0825
-	$messageSender->sendTokenToServer($config{username}, $config{password}, $master->{master_version}, $master->{version}, $args->{login_token}, $args->{len}, $master->{OTP_ip}, $master->{OTP_port});
-}
-```
-
-👉 With:
-
-```perl
-sub received_login_token {
-	my ($self, $args) = @_;
-	# XKore mode 1 / 3.
-	return if ($self->{net}->version == 1);
-	my $master = $masterServers{$config{master}};
-	return 0 if (length($args->{login_token}) == 0);
-	# rathena use 0064 not 0825
-	$messageSender->sendTokenToServer($config{username}, $config{password}, $master->{master_version}, $master->{version}, $args->{login_token}, $args->{len}, $master->{OTP_ip}, $master->{OTP_port});
-}
-```
-
-This change allows your plugin to handle and send the OTP.
-
----
-
-## ⚠ Why is Receive.pm modification required?
-
-OpenKore does not provide a built-in trigger for OTP (One-Time Password) requests when the server sends the relevant packet (e.g., `0AE3`). Although our plugin no longer needs to introduce a completely new hook, a small modification in `Receive.pm` is still necessary. This adjustment ensures that OpenKore properly calls an existing hook or passes the OTP request in a way that the plugin can detect and respond to it.
-
-➡ Without this modification, the plugin would not receive notification when the server expects the OTP code, and the automated login flow would not complete successfully.
-➡ The modification is minimal and only ensures the correct event is fired — no new hooks or extensive changes to OpenKore core are needed.
+Please ensure this PR is merged into your OpenKore before using the plugin.
 
 ---
 
@@ -104,7 +61,6 @@ server 0
 username exemple@mail.com
 password Str0ngP4ssW0rd
 loginPinCode 0123
-char 0
 otpSeed T0TPS33DROL4S3RV
 ```
 
@@ -113,8 +69,9 @@ otpSeed T0TPS33DROL4S3RV
 ## 🔑 How it works
 
 * Server sends a `0AE3` packet requesting an OTP code.
-* Modified `Receive.pm` triggers: `Plugins::callHook('login_token_requested', $messageSender);`
+* OpenKore calls the `pre_sendTokenToServer` hook.
 * The plugin generates a valid TOTP code and sends it to the server.
+* The plugin prevents `$messageSender->sendTokenToServer` from being called while the server is waiting for the OTP code.
 * Login continues automatically.
 
 ---
@@ -136,9 +93,9 @@ Fork, enhance, and share improvements — especially ideas on how to eliminate t
 
 This plugin was made possible thanks to contributions, ideas, and support from:
 
-- **pogramos** – for the idea of creating a custom Base32 decoder instead of using external libraries.
-- **SilverPhoenix28** – for sharing the way to handle OTP through `received_login_token` and `$messageSender`.
-- **OpenKore Community** – for testing, feedback, and code reviews.
+* **pogramos** – for the idea of creating a custom Base32 decoder instead of using external libraries.
+* **SilverPhoenix28** – for sharing the way to handle OTP through `received_login_token` and `$messageSender`.
+* **OpenKore Community** – for testing, feedback, and code reviews.
 
 We appreciate every idea, report, and line of code that made this plugin better!
 

--- a/README.md
+++ b/README.md
@@ -14,9 +14,6 @@ It listens for OTP requests and generates the correct TOTP code using the seed p
 
 * OpenKore (recent version with plugin system support)
 * A **Base32-encoded OTP seed** (provided by your game account)
-* Perl modules:
-  * `MIME::Base32`
-  * `Digest::SHA`
 
 ---
 
@@ -30,10 +27,11 @@ Download `otp.pl` and put it in your OpenKore `plugins/` directory:
 /openkore/plugins/OTP/otp.pl
 ```
 
-Download `Core.pm` and put them in your OpenKore `plugins/OTP/` directory:
+Download `Core.pm` and `Utils.pm`, put them in your OpenKore `plugins/OTP/` directory:
 
 ```
 /openkore/plugins/OTP/OTP/Core.pm
+/openkore/plugins/OTP/OTP/Utils.pm
 ```
 
 2️⃣ **Configure your OTP seed**

--- a/otp.pl
+++ b/otp.pl
@@ -14,14 +14,11 @@ package OTP;
 use strict;
 
 use Plugins;
+use Globals;
+use Log qw(message error);
 use lib $Plugins::current_plugin_folder;
 use OTP::Core;
 
-# Load necessary OpenKore modules
-use Globals;
-use Log qw(message error);
-
-# Register the plugin and provide unload handler
 Plugins::register(
     'otp',
     'Handles OTP requests by generating and sending TOTP',
@@ -29,13 +26,11 @@ Plugins::register(
 );
 
 # Add hook to listen for the custom OTP request event
-# This event must be triggered by a modified OpenKore source (see README.md)
+# This event must be triggered by OpenKore PR #4036
 my $hooks = Plugins::addHooks(
     ['pre_sendTokenToServer', \&hook_login_received]
 );
 
-# This function is called when OpenKore requests an OTP code.
-# It generates the TOTP code and sends it to the server.
 sub hook_login_received  {
     my (undef, $hookArgs) = @_;
     my $args = $hookArgs->{args};
@@ -60,7 +55,6 @@ sub hook_login_received  {
 }
 
 sub unload {
-    # Unregister hooks when unloading the plugin
     Plugins::delHooks($hooks);
     message "[OTP] Plugin unloaded.\n";
 }


### PR DESCRIPTION
This pull request introduces the **pre_sendTokenToServer** hook, allowing plugins to intercept and handle **OTP** (_One-Time Password_) requests during the login flow. The implementation ensures full compatibility with OpenKore Windows executables and environments that lack certain Perl modules (_e.g., Digest::SHA_).

## Key changes:
- Added pre_sendTokenToServer hook in received_login_token flow.
- Ensured OTP plugins can prevent sendTokenToServer from being called when appropriate.
- Refactored OTP code generation to remove dependencies on unavailable modules (e.g., Digest::SHA, MIME::Base32).
- Implemented pure Perl inline HMAC-SHA1 logic for TOTP generation.

This PR depends on the approval of upstream PR: [OpenKore#4036](https://github.com/OpenKore/openkore/pull/4036)